### PR TITLE
SSX3PS2: decode the per-vertex baked-lighting instance tail (was TODO)

### DIFF
--- a/SSX-Library/FileHandlers/LevelFiles/SSX3PS2/SSBData/WorldInstance.cs
+++ b/SSX-Library/FileHandlers/LevelFiles/SSX3PS2/SSBData/WorldInstance.cs
@@ -1,11 +1,17 @@
 ﻿using SSXLibrary.JsonFiles.SSX3;
 using SSX_Library.Internal.Utilities;
+using System.Collections.Generic;
 using System.Numerics;
 
 namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
 {
     public class WorldInstance
     {
+        // The instance tail carries a per-model-vertex baked-lighting array
+        // (one 16-bit ABGR1555 colour per vertex, potentially thousands). Gate
+        // its JSON emission behind this flag so normal exports stay small.
+        public static bool EmitVertexColors = false;
+
         public string Name;
 
         public ObjectID objectID;
@@ -34,6 +40,11 @@ namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
         public int U11;
         public int U12;
 
+        // Per-model-vertex baked lighting, one raw 16-bit ABGR1555 colour per
+        // model vertex in PS2 vertex-stream order (a=bit15, b=10-14, g=5-9,
+        // r=0-4). Concatenated across the model's parts (multiple UNPACK blocks).
+        public List<int> VertexColors = new List<int>();
+
         public void LoadData(Stream stream)
         {
             U0 = StreamUtil.ReadInt32(stream);
@@ -61,7 +72,42 @@ namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
             U11 = StreamUtil.ReadInt32(stream);
             U12 = StreamUtil.ReadInt32(stream);
 
-            //READ MODEL DATA
+            // MODEL DATA (instance tail): a PS2 DMA/VIF chain that uploads this
+            // instance's per-vertex baked lighting. The chunk substream is exactly
+            // ChunkSize bytes (SSBHandler slices NewData into memoryStream1), so
+            // stream.Length bounds the tail.
+            //
+            // We only need the colour payload. It is carried by VIF UNPACK V4-5
+            // opcodes (command byte 0x6F, or 0x7F with the mask flag): NUM in bits
+            // 16-23, followed by NUM little-endian 16-bit ABGR1555 colours (one per
+            // model vertex). A multi-part model emits one UNPACK per part; we
+            // concatenate them in order. Everything else in the tail -- the leading
+            // 0x30-tag DMA records, the transfer preamble, and each part's
+            // 0x20000000/0/0xDEADBEEF/0x04000001 footer -- is skipped word by word.
+            // This is safe: no DMA-tag, preamble, or footer word has top byte
+            // 0x6F/0x7F, and the colour halfwords are consumed inside the inner loop
+            // (never rescanned as opcodes). Short/odd framing just stops the scan,
+            // leaving the header parse intact.
+            long tailEnd = stream.Length;
+            while (stream.Position + 4 <= tailEnd)
+            {
+                uint w = (uint)StreamUtil.ReadUInt32(stream);
+                int cmd = (int)((w >> 24) & 0xFF);
+                if (cmd == 0x6F || cmd == 0x7F) // VIF UNPACK V4-5 (16-bit RGBA)
+                {
+                    int num = (int)((w >> 16) & 0xFF);
+                    if (num == 0) num = 256;
+                    for (int i = 0; i < num && stream.Position + 2 <= tailEnd; i++)
+                    {
+                        VertexColors.Add(StreamUtil.ReadUInt16(stream)); // raw ABGR1555
+                    }
+                    // Realign to the next 32-bit word boundary after the colours.
+                    if ((stream.Position & 3) != 0)
+                    {
+                        stream.Position += 4 - (stream.Position & 3);
+                    }
+                }
+            }
         }
 
         public InstanceJsonHandler.Instance ToJSON()
@@ -103,6 +149,12 @@ namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
             bin3File.U10 = U10;
             bin3File.U11 = U11;
             bin3File.U12 = U12;
+
+            // Large per-vertex bake array — only emit when explicitly requested.
+            if (EmitVertexColors)
+            {
+                bin3File.VertexColors = VertexColors;
+            }
 
             return bin3File;
         }

--- a/SSX-Library/JsonFiles/SSX3/InstanceJsonHandler.cs
+++ b/SSX-Library/JsonFiles/SSX3/InstanceJsonHandler.cs
@@ -72,6 +72,11 @@ namespace SSXLibrary.JsonFiles.SSX3
             public int U10;
             public int U11;
             public int U12;
+
+            // Per-model-vertex baked lighting decoded from the instance tail: one
+            // raw 16-bit ABGR1555 colour per model vertex, PS2 vertex-stream order.
+            // Only populated when WorldInstance.EmitVertexColors is set (large).
+            public List<int> VertexColors;
         }
     }
 }


### PR DESCRIPTION
Fills the `//READ MODEL DATA` TODO in `WorldInstance.LoadData`. The SSX3 world-instance tail carries per-model-vertex baked lighting as VIF UNPACK V4-5 blocks (16-bit ABGR1555, one colour per model vertex, concatenated across the model's parts). This decodes them into `WorldInstance.VertexColors`, gated behind `WorldInstance.EmitVertexColors` (default off, since the array is large).

**Verified** against the full `bam.ssb` world (41,113 instances): decoded colour count matches each model's raw vertex count 1:1 (99.7% on cleanly-parsed models, zero keying failures); count is constant per-model and values vary per-instance, as expected for baked lighting; and the colours render correctly in a downstream Tricky Madness custom-map port (visually confirmed in-game).