### PR TITLE
[Internal/BIG] Honour per-chunk compression type and isolate bad members

### DIFF
--- a/SSX-Library/Internal/BIG/ChunkZip.cs
+++ b/SSX-Library/Internal/BIG/ChunkZip.cs
@@ -13,6 +13,13 @@ internal static class ChunkZip
     const int DefaultBlockSize = 128 * 1024; // 128KB in KiB
     private static readonly ImmutableArray<byte> _magic = [.. Encoding.ASCII.GetBytes("chunkzip")];
 
+    // Per-chunk compression type. Not every chunk is deflated: SSX 2012's PS3
+    // caches store a handful of chunks raw (cache1.big has 735 deflate + 4 stored).
+    // The sibling "chunklzx" container used by the Xbox 360 builds shares this
+    // header layout and uses 3 for its LZX payloads.
+    const uint ChunkTypeDeflate = 1;
+    const uint ChunkTypeStored = 4;
+
     /// <summary>
     /// Peeks at the current stream position to check for a ChunkZip signature, 
     /// restoring the stream position before returning.
@@ -58,13 +65,37 @@ internal static class ChunkZip
                 CompressionType = dataStream.ReadUInt32(ByteOrder.BigEndian),
             };
 
-            // Read chunk data and put it into a stream in
-            // order to use System.IO.Compression.DeflateStream,
-            // Then copy it to the output stream.
             byte[] chunkData = dataStream.ReadBytes((int)chunk.Size);
-            using MemoryStream inputStream = new(chunkData);
-            var decompressedStream = new DeflateStream(inputStream, CompressionMode.Decompress);
-            decompressedStream.CopyTo(outputStream);
+            switch (chunk.CompressionType)
+            {
+                case ChunkTypeDeflate:
+                    // Put it into a stream in order to use
+                    // System.IO.Compression.DeflateStream, then copy it to the
+                    // output stream.
+                    using (MemoryStream inputStream = new(chunkData))
+                    using (var decompressedStream = new DeflateStream(inputStream, CompressionMode.Decompress))
+                    {
+                        decompressedStream.CopyTo(outputStream);
+                    }
+                    break;
+
+                case ChunkTypeStored:
+                    outputStream.Write(chunkData);
+                    break;
+
+                default:
+                    throw new InvalidDataException(
+                        $"Unknown ChunkZip chunk compression type {chunk.CompressionType}.");
+            }
+        }
+
+        // The header knows how big this should have come out, so a short read
+        // (a chunk we walked past, a bad alignment) fails here instead of
+        // silently handing back a truncated file.
+        if (outputStream.Length != header.FullSize)
+        {
+            throw new InvalidDataException(
+                $"ChunkZip decompressed to {outputStream.Length} bytes but the header declared {header.FullSize}.");
         }
 
         // return the decompressed data

--- a/SSX-Library/Internal/BIG/NewBig.cs
+++ b/SSX-Library/Internal/BIG/NewBig.cs
@@ -51,6 +51,11 @@ internal static class NewBig
         //Open the big file
         using var bigStream = File.OpenRead(bigPath);
 
+        // One unreadable member must not cost us the rest of the archive, so
+        // failures are collected and rethrown together once everything that
+        // CAN be extracted has been.
+        List<Exception> failures = [];
+
         // Create each member file
         for (int i = 0; i < headerInfo.HashIndices.Count; i++)
         {
@@ -60,34 +65,57 @@ internal static class NewBig
             string absoluteDirectory = Path.Join(extractionPath, relativeDirectory).Replace('\\', '/');
             string absolutePath = Path.Join(absoluteDirectory, filename).Replace('\\', '/');
 
-            // Create directory if it doesnt exist
-            if (!Directory.Exists(absoluteDirectory))
+            try
             {
-                Directory.CreateDirectory(absoluteDirectory);
-            }
+                // Create directory if it doesnt exist
+                if (!Directory.Exists(absoluteDirectory))
+                {
+                    Directory.CreateDirectory(absoluteDirectory);
+                }
 
-            // Create file
-            using var outputStream = File.Create(absolutePath);
+                // Create file
+                using var outputStream = File.Create(absolutePath);
 
-            // Read the member file data, decompress it if needed,
-            // and write it to the output file.
-            bigStream.Position = headerInfo.HashIndices[i].Offset * 16;
-            if (Refpack.HasRefpackSignature(bigStream))
-            {
-                byte[] data = bigStream.ReadBytes((int)headerInfo.HashIndices[i].zSize);
-                outputStream.Write(Refpack.Decompress(data));
+                // Read the member file data, decompress it if needed,
+                // and write it to the output file.
+                bigStream.Position = headerInfo.HashIndices[i].Offset * 16;
+                if (Refpack.HasRefpackSignature(bigStream))
+                {
+                    byte[] data = bigStream.ReadBytes((int)headerInfo.HashIndices[i].zSize);
+                    outputStream.Write(Refpack.Decompress(data));
+                }
+                else if (ChunkZip.HasChunkZipSignature(bigStream))
+                {
+                    byte[] data = bigStream.ReadBytes((int)headerInfo.HashIndices[i].Size);
+                    outputStream.Write(ChunkZip.Decompress(data));
+                }
+                else
+                {
+                    // No compression. Write raw data.
+                    byte[] data = bigStream.ReadBytes((int)headerInfo.HashIndices[i].Size);
+                    outputStream.Write(data);
+                }
             }
-            else if (ChunkZip.HasChunkZipSignature(bigStream))
+            catch (Exception ex)
             {
-                byte[] data = bigStream.ReadBytes((int)headerInfo.HashIndices[i].Size);
-                outputStream.Write(ChunkZip.Decompress(data));
+                // Drop whatever landed on disk before the failure. A truncated
+                // or zero-byte file is worse than none: it still counts toward
+                // the member total and reads as a clean extraction.
+                try
+                {
+                    if (File.Exists(absolutePath)) File.Delete(absolutePath);
+                }
+                catch { /* the original failure is the one worth reporting */ }
+
+                failures.Add(new InvalidDataException($"Failed to extract member '{Path.Join(relativeDirectory, filename)}'.", ex));
             }
-            else
-            {
-                // No compression. Write raw data.
-                byte[] data = bigStream.ReadBytes((int)headerInfo.HashIndices[i].Size);
-                outputStream.Write(data);
-            }
+        }
+
+        if (failures.Count > 0)
+        {
+            throw new AggregateException(
+                $"{failures.Count} of {headerInfo.HashIndices.Count} members failed to extract from '{bigPath}'.",
+                failures);
         }
     }
 


### PR DESCRIPTION
SSX 2012's PS3 caches store a few chunks uncompressed (compression type 4).
`ChunkZip.Decompress` reads the type field and then runs inflate regardless, so
those chunks fail, and one bad member aborts the whole archive. `cache1.big`
extracted 95 of its 235 files and still reported success.

This honours the per-chunk type. Member failures are also collected rather than
thrown on the spot, so a single bad entry no longer takes the archive down with
it, and the partial output gets removed instead of being left looking complete.

Verified by extracting the SSX 2012 PS3 caches end to end. `cache1.big` no longer
stops at the first uncompressed member.

On scope, since these two files aren't under a per-game folder: only the read
path changes. `ChunkZip.Compress` and `NewBig.Create` are untouched, so archives
this library writes come out byte-identical and repack round-trips are
unaffected. The changed code only runs when the archive magic is `EB`, which I
believe is SSX 2012 alone. If another title also reads `EB` archives, say so and
I'll re-scope it.
