### PR TITLE
[SSX2012] Read the GTF/CellGcmTexture header big-endian

### DIFF
--- a/SSX-Library/FileHandlers/Textures/GTFHandler.cs
+++ b/SSX-Library/FileHandlers/Textures/GTFHandler.cs
@@ -1,4 +1,4 @@
-﻿using SSX_Library.Internal.Utilities;
+using SSX_Library.Internal.Utilities;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -8,173 +8,439 @@ using System.Threading.Tasks;
 
 namespace SSXLibrary.FileHandlers.Textures
 {
+    /// <summary>
+    /// Sony Cell/RSX GTF texture container (PS3). Used by SSX (2012) for every
+    /// world texture under data/ps3/gameexplorer/worlds/textures/.
+    ///
+    /// The container is a CellGtfFileHeader followed by a CellGtfTextureAttribute
+    /// whose tail is the CellGcmTexture descriptor. Everything in it is
+    /// BIG-ENDIAN, and the pixel buffer starts at OffsetToTex (128 in practice).
+    ///
+    ///   0x00 u32 Version          0x01050000 on SSX 2012
+    ///   0x04 u32 FileLength       payload bytes following the header
+    ///   0x08 u32 NumTextures      1
+    ///   0x0c u32 TextureId        RSX texture unit id; SSX 2012 reuses it as an
+    ///                             is-normal-map flag (0 or 0x00010000)
+    ///   0x10 u32 HeaderLength     offset to the pixel buffer
+    ///   0x14 u32 TextureLength    pixel bytes, all mips and all cube faces
+    ///   0x18 u8  TextureType      Cell GCM format | LN(0x20) | UN(0x40)
+    ///   0x19 u8  NumMipmaps       level count, 1 == no mips
+    ///   0x1a u8  Dimension        2 == 2D
+    ///   0x1b u8  Cubemap          1 == six faces follow
+    ///   0x1c u32 Remaps           channel remap word
+    ///   0x20 u16 TextureWidth
+    ///   0x22 u16 TextureHeight
+    ///   0x24 u16 TextureDepth
+    ///   0x26 u8  Location
+    ///   0x27 u8  (pad)
+    ///   0x28 u32 Pitch            row stride; 0 for the compressed formats
+    ///   0x2c u32 Offset
+    ///
+    /// Layout rules that are not in the struct and have to be known:
+    ///   * A linear (LN) texture keeps its mip-0 Pitch for EVERY mip level, so
+    ///     short rows are padded out to Pitch and have to be unpacked.
+    ///   * Cube faces are padded up to a 128-byte boundary, except the last one.
+    ///   * The compressed formats ignore the SZ/LN bit - DXT blocks are always
+    ///     stored linearly.
+    /// </summary>
     public class GTFHandler
     {
         public int GTFVersion;
-        public int FileLength;  //excluding header (add len_header for full length)
-        public int NumTextures; // 1
-        public int TexIsNum; //0/1 (1 is normal/DXT5, dds2gtf.exe doesn't work with it) (int 16)
-        public int Unknown0; //0 (int 16)
-        public int HeaderLength; //128 also offset to texture buffer
-        public int TextureLength; //texture/pixel buffer (including mipmaps)
-        public int TextureType; // 0x86 (134) DXT1 | 0x88 (136) DXT5 (8)
-        public int NumMipmaps; //10 (8)
-        public int Unknown1; // (2, 0) or (512) (2 bytes)
-        public int Remaps; //not sure what remaps refers to
-        public int TextureWidth; //(int 16)
-        public int TextureHeight; //(int 16)
-        public int TextureDepth; //1 (int 16)
+        public int FileLength;   // excluding the header
+        public int NumTextures;
+        public int TextureId;    // 0, or 0x00010000 on SSX 2012 normal maps
+        public int HeaderLength; // also the offset to the pixel buffer
+        public int TextureLength;
+        public int TextureType;  // Cell GCM format byte, flags included
+        public int NumMipmaps;
+        public int Dimension;
+        public int Cubemap;
+        public int Remaps;
+        public int TextureWidth;
+        public int TextureHeight;
+        public int TextureDepth;
+        public int Location;
+        public int Pitch;
+        public int TextureOffset;
+
+        // Cell GCM base texture formats (TextureType with LN/UN masked off).
+        public const int CELL_GCM_TEXTURE_B8 = 0x81;
+        public const int CELL_GCM_TEXTURE_A1R5G5B5 = 0x82;
+        public const int CELL_GCM_TEXTURE_A4R4G4B4 = 0x83;
+        public const int CELL_GCM_TEXTURE_R5G6B5 = 0x84;
+        public const int CELL_GCM_TEXTURE_A8R8G8B8 = 0x85;
+        public const int CELL_GCM_TEXTURE_COMPRESSED_DXT1 = 0x86;
+        public const int CELL_GCM_TEXTURE_COMPRESSED_DXT23 = 0x87;
+        public const int CELL_GCM_TEXTURE_COMPRESSED_DXT45 = 0x88;
+        public const int CELL_GCM_TEXTURE_D8R8G8B8 = 0x9E;
+
+        private const int CubeFaceAlign = 128;
+
+        /// <summary>Base format with the LN (0x20) / UN (0x40) flags removed.</summary>
+        public int BaseFormat => TextureType & 0x9F;
+
+        /// <summary>True when the texel data is stored linearly rather than Morton-swizzled.</summary>
+        public bool IsLinear => (TextureType & 0x20) != 0;
+
+        public bool IsCubemap => Cubemap != 0;
+
+        public int FaceCount => IsCubemap ? 6 : 1;
+
+        /// <summary>SSX (2012) sets the otherwise-unused texture id on normal maps.</summary>
+        public bool IsNormalMap => TextureId != 0;
+
+        public void ReadHeader(Stream stream)
+        {
+            GTFVersion = StreamUtil.ReadUInt32(stream, true);
+            FileLength = StreamUtil.ReadUInt32(stream, true);
+            NumTextures = StreamUtil.ReadUInt32(stream, true);
+            TextureId = StreamUtil.ReadUInt32(stream, true);
+            HeaderLength = StreamUtil.ReadUInt32(stream, true);
+            TextureLength = StreamUtil.ReadUInt32(stream, true);
+            TextureType = StreamUtil.ReadUInt8(stream);
+            NumMipmaps = StreamUtil.ReadUInt8(stream);
+            Dimension = StreamUtil.ReadUInt8(stream);
+            Cubemap = StreamUtil.ReadUInt8(stream);
+            Remaps = StreamUtil.ReadUInt32(stream, true);
+            TextureWidth = StreamUtil.ReadUInt16(stream, true);
+            TextureHeight = StreamUtil.ReadUInt16(stream, true);
+            TextureDepth = StreamUtil.ReadUInt16(stream, true);
+            Location = StreamUtil.ReadUInt8(stream);
+            StreamUtil.ReadUInt8(stream); // padding
+            Pitch = StreamUtil.ReadUInt32(stream, true);
+            TextureOffset = StreamUtil.ReadUInt32(stream, true);
+        }
 
         public void GTFToDDS(string InputPath, string OutputPath)
         {
-            using (Stream stream = File.Open(InputPath, FileMode.Open))
+            byte[] dds;
+            using (Stream stream = File.Open(InputPath, FileMode.Open, FileAccess.Read))
             {
-                GTFVersion = StreamUtil.ReadUInt32(stream);
-                FileLength = StreamUtil.ReadUInt32(stream);
-                NumTextures = StreamUtil.ReadUInt32(stream);
-                TexIsNum = StreamUtil.ReadUInt16(stream);
-                Unknown0 = StreamUtil.ReadUInt16(stream);
-                HeaderLength = StreamUtil.ReadUInt32(stream);
-                TextureLength = StreamUtil.ReadUInt32(stream);
-                TextureType = StreamUtil.ReadUInt8(stream);
-                NumMipmaps = StreamUtil.ReadUInt8(stream);
-                Unknown1 = StreamUtil.ReadUInt16(stream);
-                Remaps = StreamUtil.ReadUInt32(stream);
-                TextureWidth = StreamUtil.ReadUInt16(stream);
-                TextureHeight = StreamUtil.ReadUInt16(stream);
-                TextureDepth = StreamUtil.ReadUInt16(stream);
-
-                string DXT_Type = "";
-                if(TextureType == 0x86)
-                {
-                    DXT_Type = "DXT1";
-                }
-                else if (TextureType == 0x88)
-                {
-                    DXT_Type = "DXT5";
-                }
-
-
-
-                byte[] Bytes = StreamUtil.ReadBytes(stream, TextureLength);
-            //https://learn.microsoft.com/en-us/windows/win32/direct3ddds/dds-header
+                dds = GTFToDDS(stream, Path.GetFileName(InputPath));
             }
+
+            string? dir = Path.GetDirectoryName(OutputPath);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                Directory.CreateDirectory(dir);
+            }
+            File.WriteAllBytes(OutputPath, dds);
+        }
+
+        /// <summary>Reads a GTF and returns a complete .dds file (header + pixels).</summary>
+        public byte[] GTFToDDS(Stream stream, string name = "<stream>")
+        {
+            ReadHeader(stream);
+
+            if (NumTextures != 1)
+            {
+                throw new NotSupportedException(
+                    $"{name}: GTF holds {NumTextures} textures, only single-texture files are supported.");
+            }
+            if (Dimension != 2)
+            {
+                throw new NotSupportedException(
+                    $"{name}: GTF dimension {Dimension}, only 2D textures are supported.");
+            }
+            if (!IsCompressed(BaseFormat) && !IsUncompressed(BaseFormat))
+            {
+                throw new NotSupportedException(
+                    $"{name}: unhandled Cell GCM texture format 0x{TextureType:X2}.");
+            }
+            if (IsUncompressed(BaseFormat) && !IsLinear)
+            {
+                // Morton/Z-order storage. Refuse rather than emit a scrambled image.
+                throw new NotSupportedException(
+                    $"{name}: swizzled (SZ) uncompressed texture, format 0x{TextureType:X2}; " +
+                    "deswizzling is not implemented.");
+            }
+
+            int expected = ExpectedTextureLength();
+            if (expected != TextureLength)
+            {
+                throw new InvalidDataException(
+                    $"{name}: mip chain works out to {expected} bytes but the header says {TextureLength}.");
+            }
+
+            stream.Position = HeaderLength;
+            // StreamUtil.ReadBytes returns a full-length buffer even on a short
+            // read, so count the bytes here or a truncated GTF converts to a
+            // DDS full of zeroes.
+            byte[] raw = new byte[TextureLength];
+            int read = 0;
+            while (read < TextureLength)
+            {
+                int n = stream.Read(raw, read, TextureLength - read);
+                if (n <= 0)
+                {
+                    break;
+                }
+                read += n;
+            }
+            if (read != TextureLength)
+            {
+                throw new InvalidDataException(
+                    $"{name}: truncated, wanted {TextureLength} pixel bytes and got {read}.");
+            }
+
+            using (MemoryStream output = new MemoryStream())
+            {
+                WriteDDSHeader(output);
+                int faceStride = FaceStride();
+                for (int face = 0; face < FaceCount; face++)
+                {
+                    int cursor = face * faceStride;
+                    for (int level = 0; level < NumMipmaps; level++)
+                    {
+                        int size = LevelStoredSize(level);
+                        WriteLevel(output, raw, cursor, level);
+                        cursor += size;
+                    }
+                }
+                return output.ToArray();
+            }
+        }
+
+        // -- geometry ---------------------------------------------------------
+
+        private static bool IsCompressed(int baseFormat)
+        {
+            return baseFormat == CELL_GCM_TEXTURE_COMPRESSED_DXT1
+                || baseFormat == CELL_GCM_TEXTURE_COMPRESSED_DXT23
+                || baseFormat == CELL_GCM_TEXTURE_COMPRESSED_DXT45;
+        }
+
+        private static bool IsUncompressed(int baseFormat)
+        {
+            return BytesPerTexel(baseFormat) > 0;
+        }
+
+        private static int BytesPerTexel(int baseFormat)
+        {
+            switch (baseFormat)
+            {
+                case CELL_GCM_TEXTURE_B8: return 1;
+                case CELL_GCM_TEXTURE_A1R5G5B5:
+                case CELL_GCM_TEXTURE_A4R4G4B4:
+                case CELL_GCM_TEXTURE_R5G6B5: return 2;
+                case CELL_GCM_TEXTURE_A8R8G8B8:
+                case CELL_GCM_TEXTURE_D8R8G8B8: return 4;
+                default: return 0;
+            }
+        }
+
+        private static int BlockBytes(int baseFormat)
+        {
+            return baseFormat == CELL_GCM_TEXTURE_COMPRESSED_DXT1 ? 8 : 16;
+        }
+
+        private int LevelWidth(int level) => Math.Max(1, TextureWidth >> level);
+
+        private int LevelHeight(int level) => Math.Max(1, TextureHeight >> level);
+
+        /// <summary>Bytes one mip level occupies as stored in the GTF.</summary>
+        public int LevelStoredSize(int level)
+        {
+            int w = LevelWidth(level);
+            int h = LevelHeight(level);
+            if (IsCompressed(BaseFormat))
+            {
+                return ((w + 3) / 4) * ((h + 3) / 4) * BlockBytes(BaseFormat);
+            }
+            return StoredPitch() * h;
+        }
+
+        private int StoredPitch()
+        {
+            return Pitch > 0 ? Pitch : TextureWidth * BytesPerTexel(BaseFormat);
+        }
+
+        private int FaceSize()
+        {
+            int total = 0;
+            for (int level = 0; level < NumMipmaps; level++)
+            {
+                total += LevelStoredSize(level);
+            }
+            return total;
+        }
+
+        private int FaceStride()
+        {
+            int face = FaceSize();
+            if (!IsCubemap)
+            {
+                return face;
+            }
+            return (face + CubeFaceAlign - 1) / CubeFaceAlign * CubeFaceAlign;
+        }
+
+        /// <summary>What TextureLength should be, given the header's geometry.</summary>
+        public int ExpectedTextureLength()
+        {
+            int face = FaceSize();
+            if (!IsCubemap)
+            {
+                return face;
+            }
+            // Every face but the last is padded up to the 128-byte boundary.
+            return FaceStride() * (FaceCount - 1) + face;
+        }
+
+        // -- pixels -----------------------------------------------------------
+
+        private void WriteLevel(Stream output, byte[] raw, int offset, int level)
+        {
+            if (IsCompressed(BaseFormat))
+            {
+                output.Write(raw, offset, LevelStoredSize(level));
+                return;
+            }
+
+            int bpp = BytesPerTexel(BaseFormat);
+            int w = LevelWidth(level);
+            int h = LevelHeight(level);
+            int rowBytes = w * bpp;
+            int stride = StoredPitch();
+            byte[] row = new byte[rowBytes];
+            for (int y = 0; y < h; y++)
+            {
+                Array.Copy(raw, offset + y * stride, row, 0, rowBytes);
+                SwapTexelBytes(row, bpp);
+                output.Write(row, 0, rowBytes);
+            }
+        }
+
+        /// <summary>
+        /// GTF stores multi-byte texels big-endian; the DDS channel masks below
+        /// assume little-endian, so each texel is byte-reversed. Single-byte
+        /// formats need nothing.
+        /// </summary>
+        private static void SwapTexelBytes(byte[] row, int bpp)
+        {
+            if (bpp < 2)
+            {
+                return;
+            }
+            for (int i = 0; i + bpp <= row.Length; i += bpp)
+            {
+                Array.Reverse(row, i, bpp);
+            }
+        }
+
+        // -- DDS container ----------------------------------------------------
+
+        private const int DDSD_CAPS = 0x1;
+        private const int DDSD_HEIGHT = 0x2;
+        private const int DDSD_WIDTH = 0x4;
+        private const int DDSD_PITCH = 0x8;
+        private const int DDSD_PIXELFORMAT = 0x1000;
+        private const int DDSD_MIPMAPCOUNT = 0x20000;
+        private const int DDSD_LINEARSIZE = 0x80000;
+
+        private const int DDSCAPS_COMPLEX = 0x8;
+        private const int DDSCAPS_TEXTURE = 0x1000;
+        private const int DDSCAPS_MIPMAP = 0x400000;
+        private const int DDSCAPS2_CUBEMAP_ALLFACES = 0xFE00;
+
+        private const int DDPF_ALPHAPIXELS = 0x1;
+        private const int DDPF_FOURCC = 0x4;
+        private const int DDPF_RGB = 0x40;
+        private const int DDPF_LUMINANCE = 0x20000;
+
+        private void WriteDDSHeader(Stream output)
+        {
+            int flags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT;
+            int caps = DDSCAPS_TEXTURE;
+            if (NumMipmaps > 1)
+            {
+                flags |= DDSD_MIPMAPCOUNT;
+                caps |= DDSCAPS_MIPMAP | DDSCAPS_COMPLEX;
+            }
+            int caps2 = 0;
+            if (IsCubemap)
+            {
+                caps |= DDSCAPS_COMPLEX;
+                caps2 = DDSCAPS2_CUBEMAP_ALLFACES;
+            }
+
+            int pitchOrLinearSize;
+            int pfFlags;
+            string fourCC = "\0\0\0\0";
+            int bitCount = 0, rMask = 0, gMask = 0, bMask = 0, aMask = 0;
+
+            if (IsCompressed(BaseFormat))
+            {
+                flags |= DDSD_LINEARSIZE;
+                pitchOrLinearSize = ((TextureWidth + 3) / 4) * ((TextureHeight + 3) / 4)
+                                    * BlockBytes(BaseFormat);
+                pfFlags = DDPF_FOURCC;
+                fourCC = BaseFormat == CELL_GCM_TEXTURE_COMPRESSED_DXT1 ? "DXT1"
+                       : BaseFormat == CELL_GCM_TEXTURE_COMPRESSED_DXT23 ? "DXT3"
+                       : "DXT5";
+            }
+            else
+            {
+                flags |= DDSD_PITCH;
+                pitchOrLinearSize = TextureWidth * BytesPerTexel(BaseFormat);
+                switch (BaseFormat)
+                {
+                    case CELL_GCM_TEXTURE_B8:
+                        pfFlags = DDPF_LUMINANCE; bitCount = 8; rMask = 0xFF;
+                        break;
+                    case CELL_GCM_TEXTURE_R5G6B5:
+                        pfFlags = DDPF_RGB; bitCount = 16;
+                        rMask = 0xF800; gMask = 0x07E0; bMask = 0x001F;
+                        break;
+                    case CELL_GCM_TEXTURE_A1R5G5B5:
+                        pfFlags = DDPF_RGB | DDPF_ALPHAPIXELS; bitCount = 16;
+                        rMask = 0x7C00; gMask = 0x03E0; bMask = 0x001F; aMask = unchecked((int)0x8000);
+                        break;
+                    case CELL_GCM_TEXTURE_A4R4G4B4:
+                        pfFlags = DDPF_RGB | DDPF_ALPHAPIXELS; bitCount = 16;
+                        rMask = 0x0F00; gMask = 0x00F0; bMask = 0x000F; aMask = unchecked((int)0xF000);
+                        break;
+                    case CELL_GCM_TEXTURE_A8R8G8B8:
+                        pfFlags = DDPF_RGB | DDPF_ALPHAPIXELS; bitCount = 32;
+                        rMask = 0x00FF0000; gMask = 0x0000FF00; bMask = 0x000000FF;
+                        aMask = unchecked((int)0xFF000000);
+                        break;
+                    default: // CELL_GCM_TEXTURE_D8R8G8B8
+                        pfFlags = DDPF_RGB; bitCount = 32;
+                        rMask = 0x00FF0000; gMask = 0x0000FF00; bMask = 0x000000FF;
+                        break;
+                }
+            }
+
+            StreamUtil.WriteString(output, "DDS ");
+            StreamUtil.WriteInt32(output, 124);              // dwSize
+            StreamUtil.WriteInt32(output, flags);
+            StreamUtil.WriteInt32(output, TextureHeight);
+            StreamUtil.WriteInt32(output, TextureWidth);
+            StreamUtil.WriteInt32(output, pitchOrLinearSize);
+            StreamUtil.WriteInt32(output, 0);                // dwDepth
+            StreamUtil.WriteInt32(output, NumMipmaps);
+            StreamUtil.WriteBytes(output, new byte[44]);     // dwReserved1[11]
+
+            StreamUtil.WriteInt32(output, 32);               // DDS_PIXELFORMAT.dwSize
+            StreamUtil.WriteInt32(output, pfFlags);
+            StreamUtil.WriteString(output, fourCC);
+            StreamUtil.WriteInt32(output, bitCount);
+            StreamUtil.WriteInt32(output, rMask);
+            StreamUtil.WriteInt32(output, gMask);
+            StreamUtil.WriteInt32(output, bMask);
+            StreamUtil.WriteInt32(output, aMask);
+
+            StreamUtil.WriteInt32(output, caps);
+            StreamUtil.WriteInt32(output, caps2);
+            StreamUtil.WriteInt32(output, 0);                // dwCaps3
+            StreamUtil.WriteInt32(output, 0);                // dwCaps4
+            StreamUtil.WriteInt32(output, 0);                // dwReserved2
         }
 
         public void DDSToGTF(string path)
         {
-            using (Stream stream = File.Open(path, FileMode.Open))
-            {
-
-            }
+            throw new NotImplementedException("DDS -> GTF is not implemented.");
         }
-
-//# New DDS buffer
-
-//        dds_buffer = b'DDS\x20\x7c\x00\x00\x00\x07\x10\x0a\x00'
-//        dds_buffer += s.pack('<I', tex_height)
-//        dds_buffer += s.pack('<I', tex_width)
-//        dds_buffer += b'\x00\x00'
-//        if dxt_type == 'DXT1':
-//            dds_buffer += b'\x02\x00'
-//        else:
-//            dds_buffer += b'\x04\x00'
-//        dds_buffer += b'\x00\x00\x00\x00'
-//        dds_buffer += s.pack('<I', num_mipmaps)
-//        dds_buffer += b'\x00' * 44
-//        dds_buffer += b'\x20\x00\x00\x00'
-//        dds_buffer += b'\x04\x00\x00\x00'
-//        dds_buffer += dxt_type.encode('utf-8')
-//        dds_buffer += b'\x00' * 20
-//        dds_buffer += b'\x08\x10\x40\x00'
-//        dds_buffer += b'\x00' * 16
-
-//        dds_buffer += tex_buffer
-
-//        with open(self.out_file_path, 'wb') as f:
-//            f.write(dds_buffer)
-
-//        print(f"\nOutput path:\n{os.path.abspath(self.out_file_path)}\nFinished converting!")
-
-
-//    def dds_to_gtf(self):
-//        self.out_file_path += '.gtf'
-
-//        with open(self.in_file_path, 'rb') as f:
-
-//            f.seek(4)
-//            len_header = get_uint32(f) + 4
-//            f.seek(0xc)
-//            tex_height = get_uint32(f)
-//            tex_width  = get_uint32(f)
-//            len_tex_linear = get_uint32(f) # byte size of first texture
-//            f.seek(0x1c)
-//            num_mipmaps = get_uint32(f)
-//            f.seek(0x4c)
-//            pixel_format0 = get_uint32(f) # size?  # DDSPixelFormat
-//            pixel_format1 = get_uint32(f) # flags?
-//            dxt_type = get_string(f, 4)
-
-//            len_block = 16
-//            if dxt_type == 'DXT1':
-//                len_block = 8
-//            elif dxt_type == 'DXT5':
-//                len_block = 16
-//            else:
-//                print("Unknown DXT type. Trying DXT5.")
-
-//            len_texture = 0 # including mipmaps
-//            mip_w = tex_width
-//            mip_h = tex_height
-//            for i in range(num_mipmaps) : # idk if this is the right way but it seems to work
-//                len_mip = (mip_w // 4) * (mip_h // 4) * len_block
-//                len_texture += len_mip
-
-//                mip_w = mip_w / 2
-//                mip_h = mip_h / 2
-
-//            len_texture = int (len_texture + len_block* 2)
-//            len_end_buffer = self.len_in_file - len_header
-            
-//            if len_texture<len_end_buffer:
-//                print("len_texture is less than len_end_buffer. Using len_end_buffer.")
-//                len_texture = len_end_buffer
-
-//            f.seek(len_header)
-
-//            tex_buffer = f.read(len_texture)
-
-//        end_padding = calc_padding(len_texture) + 32
-//        tex_is_nm = b''
-//        if dxt_type == 'DXT1':
-//            tex_is_nm += b'\x00\x00\x00\x00'
-//            tex_type = b'\x86'
-//        else:
-//            tex_is_nm += b'\x00\x01\x00\x00'
-//            tex_type = b'\x88'
-
-//        gtf_buffer = b'\x01\x05\x00\x00'
-//        gtf_buffer += s.pack('>I', len_texture + end_padding)
-//        gtf_buffer += b'\x00\x00\x00\x01' # num_textures
-//        gtf_buffer += tex_is_nm
-//        gtf_buffer += b'\x00\x00\x00\x80' # len_header
-//        gtf_buffer += s.pack('>I', len_texture)
-//        gtf_buffer += tex_type
-//        gtf_buffer += s.pack('B', num_mipmaps)
-//        gtf_buffer += b'\x02\x00\x00\x00\xaa\xe4'
-//        gtf_buffer += s.pack('>H', tex_width)
-//        gtf_buffer += s.pack('>H', tex_height)
-//        gtf_buffer += b'\x00\x01' # tex_depth
-//        gtf_buffer += b'\x00' * 0x5a # 0xa + 0x50
-
-//        gtf_buffer += tex_buffer
-//        gtf_buffer += b'\x00' * end_padding
-
-//# print(len_texture + calc_padding(len_texture) + 16)
-
-//        with open(self.out_file_path, 'wb') as f:
-//            f.write(gtf_buffer)
-
-//        print(f"\nOutput path:\n{os.path.abspath(self.out_file_path)}\nFinished converting!")
     }
 }


### PR DESCRIPTION
GTF wraps a PS3 `CellGcmTexture` header, which is big-endian. Every field is read
little-endian here, so width, height and format come out byte-swapped on all 540
textures in the SSX 2012 pool. 58.7% of them throw `OverflowException` and the
rest allocate garbage buffers.

This reads the header in its native endianness and adds the three layout rules
the struct doesn't express: linear mips keep the mip-0 pitch instead of halving
it, cube faces are 128-byte aligned except for the last, and compressed mips run
down to 1x1 at a full block rather than a partial one.

I avoided `StreamUtil.ReadBytes` in this path deliberately. It returns a
full-length buffer on a short read, which silently turns a truncated file into a
DDS of zeroes instead of an error.

One note on scope, since `GTFHandler` sits in the shared `FileHandlers/Textures/`
rather than under a game folder. GTF is a PS3 container and SSX 2012 looks like
the only PS3 title the library handles right now, so nothing else should reach
this today. I've treated it as an endianness fix rather than an SSX 2012 special
case, on the grounds that the old little-endian reads couldn't have been correct
for any GTF file. If you have GTFs from another title that currently work, say so
and I'll gate it instead.

All 540 convert after this, byte-identical to a Python implementation written
from the `CellGcmTexture` layout rather than ported from this code. Same offer as
the GEOM PR: I can contribute that as a test oracle if it's useful.
