### PR TITLE
[SSX3PS2] Stop dropping whole prefabs on a non-zero model-record U2 byte

### DIFF
--- a/SSX-Library/FileHandlers/LevelFiles/SSX3PS2/SSBData/WorldMDR.cs
+++ b/SSX-Library/FileHandlers/LevelFiles/SSX3PS2/SSBData/WorldMDR.cs
@@ -193,7 +193,13 @@ namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
                     {
                         var ModelHeader = S1.unknownS2.ModelHeaderOffset[a];
                         bool HeaderStart = false;
-                        bool Normal = false;
+                        // Pairing robustness. An earlier revision decided
+                        // V/UV vs normal records with a `Normal` toggle that only
+                        // flipped on ModelOffset > 0, while ConvertToModelFaces pairs
+                        // records STRICTLY positionally (k*2 = V/UV, k*2+1 = normals).
+                        // The moment a record has ModelOffset <= 0 the two passes
+                        // desync. Drive the split off record position (b % 2) so it
+                        // always agrees with the positional pairing below.
                         for (int b = 0; b < ModelHeader.ModelOffsetHeaders.Count - 1; b++)
                         {
                             var ModelOffsetHeader = ModelHeader.ModelOffsetHeaders[b];
@@ -213,7 +219,7 @@ namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
                                     HeaderStart = true;
                                 }
 
-                                if (!Normal)
+                                if (b % 2 == 0)
                                 {
                                     stream.Position += 32;
                                     ModelVandUVData TempModelData = new ModelVandUVData();
@@ -225,6 +231,21 @@ namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
                                     TempModelData.VerticesCount = StreamUtil.ReadUInt32(stream);
 
                                     stream.Position += 4 + 16;
+
+                                    // Guard against absurd counts on a recovered
+                                    // (formerly U2-aborted) record: leave the lists
+                                    // empty so the pair is skipped downstream rather
+                                    // than reading a multi-MB garbage blob.
+                                    if (TempModelData.TristripCount > 100000 || TempModelData.VerticesCount > 100000)
+                                    {
+                                        Console.WriteLine($"[WorldMDR] RID={objectID.RID} obj={i} hdr={a} rec={b}: insane counts Tristrip={TempModelData.TristripCount} Verts={TempModelData.VerticesCount}; dropping record geometry");
+                                        TempModelData.Tristrip = new List<int>();
+                                        TempModelData.UV = new List<Vector2>();
+                                        TempModelData.Vertices = new List<Vector3>();
+                                        ModelOffsetHeader.modelVandUVData = TempModelData;
+                                        ModelHeader.ModelOffsetHeaders[b] = ModelOffsetHeader;
+                                        continue;
+                                    }
 
                                     TempModelData.Tristrip = new List<int>();
 
@@ -291,8 +312,13 @@ namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
 
                                     ModelOffsetHeader.modelNormalData = TempModelData;
                                 }
-
-                                Normal = !Normal;
+                            }
+                            else
+                            {
+                                // Non-terminator record (b < Count-1) with no model
+                                // data. Leave its geometry lists null; the pair it
+                                // belongs to is null-guarded in ConvertToModelFaces.
+                                Console.WriteLine($"[WorldMDR] RID={objectID.RID} obj={i} hdr={a} rec={b}: non-terminator record with ModelOffset={ModelOffsetHeader.ModelOffset} (<=0), no geometry");
                             }
 
                             ModelHeader.ModelOffsetHeaders[b] = ModelOffsetHeader;
@@ -322,13 +348,27 @@ namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
                         S2.modelFaces = new List<ModelFace>();
                         for (int k = 0; k < S2.ModelOffsetHeaders.Count / 2; k++)
                         {
-                            var S3 = S2.ModelOffsetHeaders[k * 2];
-
                             int VerticesUVID = k * 2;
                             int NormalID = k * 2 + 1;
 
                             var VerticesUV = S2.ModelOffsetHeaders[VerticesUVID];
                             var Normal = S2.ModelOffsetHeaders[NormalID];
+
+                            // Pairing robustness. GenerateFaces NREs
+                            // on a null Vertices/UV/Normals list, and nothing in the
+                            // SSX3PS2 chain catches it. A record can legitimately have
+                            // no geometry now (terminator paired with an orphan V/UV
+                            // record, or a ModelOffset<=0 record) -- skip and log that
+                            // pair instead of throwing away the whole extract.
+                            if (VerticesUV.modelVandUVData.Vertices == null ||
+                                VerticesUV.modelVandUVData.UV == null ||
+                                VerticesUV.modelVandUVData.Tristrip == null ||
+                                Normal.modelNormalData.Normals == null ||
+                                Normal.modelNormalData.Normals.Count == 0)
+                            {
+                                Console.WriteLine($"[WorldMDR] RID={objectID.RID} obj={i} hdr={j} pair={k}: null/empty V/UV or normals, skipping pair");
+                                continue;
+                            }
 
                             S2.modelFaces.AddRange(GenerateFaces(VerticesUV.modelVandUVData, Normal.modelNormalData));
 
@@ -353,6 +393,12 @@ namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
 
             //Make Faces
             List<ModelFace> faces = new List<ModelFace>();
+            // The normal list can be shorter than the vertex list on a
+            // recovered record; CreateFaces clamps the normal index. Log once here.
+            if (modelNormalData.Normals.Count < ModelData.Vertices.Count)
+            {
+                Console.WriteLine($"[WorldMDR] RID={objectID.RID}: normals {modelNormalData.Normals.Count} < verts {ModelData.Vertices.Count}; clamping normal indices for this mesh");
+            }
             int localIndex = 0;
             bool Rotation = false;
             for (int b = 0; b < ModelData.Vertices.Count; b++)
@@ -425,9 +471,13 @@ namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
             //face.UV2Pos = Index2;
             //face.UV3Pos = Index3;
 
-            face.Normal1 = modelNormalData.Normals[Index1];
-            face.Normal2 = modelNormalData.Normals[Index2];
-            face.Normal3 = modelNormalData.Normals[Index3];
+            // Clamp normal indices: the normal list may be shorter
+            // than the vertex list on a recovered record (one-per-mesh log emitted in
+            // GenerateFaces). UV/Vertices are the same length so those are safe.
+            int nMax = modelNormalData.Normals.Count - 1;
+            face.Normal1 = modelNormalData.Normals[Index1 < nMax ? Index1 : nMax];
+            face.Normal2 = modelNormalData.Normals[Index2 < nMax ? Index2 : nMax];
+            face.Normal3 = modelNormalData.Normals[Index3 < nMax ? Index3 : nMax];
 
             //face.Normal1Pos = Index1;
             //face.Normal2Pos = Index2;

--- a/SSX-Library/FileHandlers/LevelFiles/SSX3PS2/SSBData/WorldMDR.cs
+++ b/SSX-Library/FileHandlers/LevelFiles/SSX3PS2/SSBData/WorldMDR.cs
@@ -95,8 +95,35 @@ namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
 
                         stream.Position = TempS5.ModelDataOffset + ModelDataOffset;
 
+                        // U2 handling. Returning from here aborts the ENTIRE
+                        // prefab (`return` from LoadData) the first time a model
+                        // record has U2 != 0, so every ModelObject/part after that
+                        // point exports zero faces. Evidence (full-mountain extract,
+                        // logged below) shows U2 is a *flag bit* on an otherwise
+                        // valid record: it carries a valid positive ModelOffset and
+                        // the record chain still terminates on the normal U1 == 96
+                        // record a few entries later. It is NOT the high byte of a
+                        // 32-bit ModelOffset -- (U2 << 24) | ModelOffset lands far
+                        // out of the (few-KB) prefab chunk on every hit. So we mask
+                        // the flag and keep reading, preserving the record (and its
+                        // geometry) and the positional V/UV<->normal pairing. Guard
+                        // the loop with an iteration cap and a stream-bounds check so
+                        // a genuinely malformed chain degrades to "break this header
+                        // group" instead of running away or throwing.
+                        int _recGuard = 0;
                         while (true)
                         {
+                            if (stream.Position + 8 > stream.Length)
+                            {
+                                Console.WriteLine($"[WorldMDR] RID={objectID.RID} obj={i} hdr={a}: record loop reached end-of-stream (pos={stream.Position} len={stream.Length}); breaking header group");
+                                break;
+                            }
+                            if (++_recGuard > 4096)
+                            {
+                                Console.WriteLine($"[WorldMDR] RID={objectID.RID} obj={i} hdr={a}: record loop exceeded 4096 iterations; breaking header group");
+                                break;
+                            }
+
                             ModelData TempS7 = new ModelData();
 
                             TempS7.LineCount = StreamUtil.ReadInt24(stream);
@@ -105,8 +132,10 @@ namespace SSXLibrary.FileHandlers.LevelFiles.SSX3PS2.SSBData
                             TempS7.U2 = StreamUtil.ReadUInt8(stream);
                             if (TempS7.U2 != 0)
                             {
-                                Console.WriteLine(TempS7.U2 + " Detected");
-                                return;
+                                int combinedOffset = (TempS7.U2 << 24) | (TempS7.ModelOffset & 0xFFFFFF);
+                                long combinedTarget = (long)combinedOffset + ModelDataOffset;
+                                Console.WriteLine($"[WorldMDR] flag ignored RID={objectID.RID} obj={i} hdr={a} rec={TempS5.ModelOffsetHeaders.Count} U2={TempS7.U2} U1={TempS7.U1} LineCount={TempS7.LineCount} ModelOffset={TempS7.ModelOffset} (rejected 32-bit hypothesis: combined={combinedOffset} target={combinedTarget} len={stream.Length})");
+                                TempS7.U2 = 0;
                             }
                             TempS5.ModelOffsetHeaders.Add(TempS7);
 


### PR DESCRIPTION
`WorldMDR.LoadData` returns from the entire prefab the first time a model record
has a non-zero `U2` byte, so every ModelObject and part in that WorldMDR exports
zero faces. On the SSX 3 mountain that drops whole break and shortcut prefabs.
ERA5 RID 301, DRA4 RID 4 and CRA3 RID 215 all come out with 4/4 parts empty, plus
roughly 15 more objects per race region. The extraction reports success, which is
the part that took a while to spot.

Logging the field values across a full-mountain extract shows `U2` is a flag bit
on an otherwise valid record. The record still carries a positive `ModelOffset`,
and the chain terminates normally on a `U1==96` record a few entries later. It is
not the high byte of a 32-bit offset: treating it as one puts
`(U2<<24)|ModelOffset` gigabytes outside a prefab chunk that is a few KB long, on
every single hit.

The first commit masks the flag and keeps reading, with a 4096-iteration cap and
a stream-bounds check so a genuinely malformed chain degrades to breaking one
header group rather than running away.

The second commit deals with the consequence. Once those records survive, a
header group can legitimately contain an orphan V/UV record paired against the
terminator, whose normal data is null, and `GenerateFaces` dereferences the
Vertices/UV/Normals lists without checking. Nothing in the SSX3PS2 chain catches
the resulting NRE, so one bad record would still kill the extract. It splits
V/UV from normal records by record position instead of a toggle that desynced the
moment a record had `ModelOffset <= 0`, skips and logs a pair with missing lists,
clamps the normal index where the normal list is shorter than the vertex list,
and drops records with implausible counts rather than reading a garbage blob.

The two belong together. The first widens what gets through the reader without
the null handling to cope with it, so it isn't much use on its own.

For well-formed prefabs the output is byte-identical: no `ModelOffset <= 0`
records, normal count matching the vertex count, sane counts. Only geometry that
previously aborted changes.

Diagnostics go to `Console.WriteLine` to match the rest of the library.
